### PR TITLE
Add README, simplify some logic, make blank line separator easier to configure alongside objectMode

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ fs.createReadStream("some_unix_file.txt").pipe(converter).pipe(process.stdout);
 Or just grab the lines:
 
 ```js
-var LineStream = require('./'),
+var LineStream = require('linefeed'),
     splitter = new LineStream({newline:"", objectMode:true});
 fs.createReadStream("README.md").pipe(splitter).on('data', function (line) {
     console.log("Got a line:", line);

--- a/README.md
+++ b/README.md
@@ -1,0 +1,56 @@
+# linefeed
+
+A transform stream which converts various line endings into simple newlines, conveniently emitting a single chunk per line.
+
+## Library usage
+
+Convert Windows linefeeds to Unix:
+
+```js
+var fixlines = require('linefeed');
+fs.createReadStream("WINDWS~1.TXT").pipe(fixlines()).pipe(process.stdout);
+```
+
+Or vice versa:
+
+```js
+var LineStream = require('linefeed'),
+    converter = new LineStream({newline:"\r"});
+fs.createReadStream("some_unix_file.txt").pipe(converter).pipe(process.stdout);
+```
+
+Or just grab the lines:
+
+```js
+var LineStream = require('./'),
+    splitter = new LineStream({newline:"", objectMode:true});
+fs.createReadStream("README.md").pipe(splitter).on('data', function (line) {
+    console.log("Got a line:", line);
+});
+```
+
+Besides the usual [stream.Transform](http://nodejs.org/api/stream.html#stream_class_stream_transform) configuration, the only other option is `{newline:string}`. Set it to any desired newline separator, including the empty string (which is especially useful with an object mode transform).
+
+
+## CLI
+
+There is also a minimal shell script you can pipe through if installed globally (or locally, if "./node_modules/.bin/" is in your path):
+
+```sh
+cat README.md | linefeed > README.unix_endings.txt
+
+```
+
+Currently no options can be provided.
+
+
+## MIT License
+
+Copyright (c) 2013 Jacob Smartwood
+Copyright (c) 2014 Nathan Vander Wilt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ util.inherits(LineStream, stream.Transform);
 LineStream.prototype._transform = function _transform( chunk, encoding, done ) {
 	var lines = chunk.toString().split(lineMatcher),
 			last = lines.length - 1;
-	
+
 	lines[0] = this._temp + lines[0]
 	for (var i = 0; i < last; i++) {
 		this.push(lines[i]+this.newline);

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ function LineStream( opts ) {
 
 	stream.Transform.call(this, opts);
 
-	this.newline = "\n";
+	this.newline = (opts && 'newline' in opts) ? opts.newline : "\n";
 	this._temp = "";
 }
 
@@ -24,7 +24,7 @@ LineStream.prototype._transform = function _transform( chunk, encoding, done ) {
 		if (i < last) {
 			this.push(this._temp + lines[i])
 			this._temp = "";
-			this.push(this.newline);
+			if (this.newline) this.push(this.newline);
 		} else {
 			this._temp += lines[i];
 		}

--- a/index.js
+++ b/index.js
@@ -19,15 +19,12 @@ LineStream.prototype._transform = function _transform( chunk, encoding, done ) {
 	var lines = chunk.toString().split(lineMatcher),
 			last = lines.length - 1;
 	
-	for (var i = 0; i <= last; i++) {
-		if (i < last) {
-			this.push(this._temp + lines[i])
-			this._temp = "";
-			if (this.newline) this.push(this.newline);
-		} else {
-			this._temp += lines[i];
-		}
+	lines[0] = this._temp + lines[0]
+	for (var i = 0; i < last; i++) {
+		this.push(lines[i]);
+		if (this.newline) this.push(this.newline);
 	}
+	this._temp = lines[last];
 
 	done();
 };

--- a/index.js
+++ b/index.js
@@ -13,7 +13,6 @@ function LineStream( opts ) {
 	this._temp = "";
 }
 
-//StatusStream.prototype = Object.create(stream.Transform.prototype, { constructor: { value: stream.Transform }});
 util.inherits(LineStream, stream.Transform);
 
 LineStream.prototype._transform = function _transform( chunk, encoding, done ) {

--- a/index.js
+++ b/index.js
@@ -21,8 +21,7 @@ LineStream.prototype._transform = function _transform( chunk, encoding, done ) {
 	
 	lines[0] = this._temp + lines[0]
 	for (var i = 0; i < last; i++) {
-		this.push(lines[i]);
-		if (this.newline) this.push(this.newline);
+		this.push(lines[i]+this.newline);
 	}
 	this._temp = lines[last];
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "Transforms a stream into newline separated chunks.",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha ./test"
+    "test": "./node_modules/.bin/mocha ./test"
+  },
+  "bin": {
+    "linefeed": "./bin/linefeed"
   },
 	"devDependencies": {
 		"mocha": "*",


### PR DESCRIPTION
Here's a variety of cleanup, mostly focused on getting clean single-line chunks in objectMode. Found this package today since it had the name I was gonna use if I couldn't find a nice simple "split a stream into lines" implementation already. So I figured I'd just run with yours ;-) Also added a README for good measure.

If this looks good to you, perhaps you could bump the package version and republish? (It should be fully backwards compatible, but might be worth a 0.2.0 since it's more than/not a bugfix.)
